### PR TITLE
Fix unicode issues in data with ftfy

### DIFF
--- a/filter_data.py
+++ b/filter_data.py
@@ -1,17 +1,28 @@
+import argparse
 import sys
 import csv
 import json
 
-# Takes summaries from narrative qa, and truncates them till a paragraph boundary such that there are at most 3000
-# characters in the passage.
+argparser = argparse.ArgumentParser("Take summaries from NarrativeQA, and truncate "
+                                    "them until a paragraph boundary, such that there "
+                                    "are at most 3000 characters in the passage.")
+argparser.add_argument('--data-path', type=str,
+                       help=("Path to CSV file with summaries from the NarrativeQA "
+                             "dataset."), required=True)
+argparser.add_argument('--output-path', type=str,
+                       help=("Path to JSON file of passages to write out."), required=True)
+args = argparser.parse_args()
 
-# Assuming this file is the one with summaries from the narrativeqa dataset
-reader = csv.reader(open(sys.argv[1]))
+
+# Assuming this file is the one with summaries from the NarrativeQA dataset
+reader = csv.reader(open(args.data_path))
 all_passages = [row[2].strip() for row in reader if row[1] == "train"]
 filtered_passages = []
 
 for passage in all_passages:
-    paragraphs = passage.split("\n")
+    # Fix unicode issues in passage
+    fixed_passage = ftfy.fix_text(passage)
+    paragraphs = fixed_passage.split("\n")
     paragraphs_to_keep = []
     len_so_far = 0
     for paragraph in paragraphs:
@@ -24,4 +35,4 @@ for passage in all_passages:
 
 json_output = {"passages": filtered_passages}
 
-json.dump(json_output, open(sys.argv[2], "w"))
+json.dump(json_output, open(args.output_path, "w"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto3
 beautifulsoup4
+ftfy


### PR DESCRIPTION
Some of the passages in our source data have unicode issues. For instance, look at line `6010` of `summaries.csv`. In the annotation interface, this looks like:
<img width="536" alt="Screen Shot 2019-03-14 at 2 07 27 PM" src="https://user-images.githubusercontent.com/7272031/54391628-a1fd9280-4662-11e9-98cb-632f2a0c6535.png">

This PR uses the `ftfy` package to correct some of these unicode issues, like so:

```
In [1]: import ftfy

In [2]: s = ' The play is set at ""Fin de siĂ¨cle 15-1600. Midsummer night on the terrace of the Palace a
   ...: t Whitehall, overlooking the Thames. The Palace clock chimes four quarters and strikes eleven.'

In [3]: s
Out[3]: ' The play is set at ""Fin de siĂ¨cle 15-1600. Midsummer night on the terrace of the Palace at Whitehall, overlooking the Thames. The Palace clock chimes four quarters and strikes eleven.'

In [4]: ftfy.fix_text(s)
Out[4]: ' The play is set at ""Fin de siècle 15-1600. Midsummer night on the terrace of the Palace at Whitehall, overlooking the Thames. The Palace clock chimes four quarters and strikes eleven.'
```